### PR TITLE
Adjustments for Vagrant dev VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 build
+config.py
+/venv

--- a/deploy/eleven-spritesheet-generator.service
+++ b/deploy/eleven-spritesheet-generator.service
@@ -1,0 +1,22 @@
+# Systemd unit file for running the spritesheet generator as a service.
+# The following configuration assumes the package is installed in:
+#
+# /eleven/eleven-spritesheet-generator
+#
+# and a virtual Python environment called "venv" is present there.
+# It also assumes RabbitMQ is running as a systemd service on the same host.
+# Please adjust as needed.
+
+[Unit]
+Description=Eleven Giants Spritesheet Generator
+Requires=rabbitmq-server.service
+After=rabbitmq-server.service
+
+[Service]
+User=eleven
+Group=eleven
+WorkingDirectory=/eleven/eleven-spritesheet-generator
+ExecStart=/bin/bash -c 'source venv/bin/activate && python -m scripts/eleven_spritesheet_generator_worker --config=./config.py'
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/eleven-spritesheet-generator.service.VAGRANT
+++ b/deploy/eleven-spritesheet-generator.service.VAGRANT
@@ -1,0 +1,16 @@
+# Systemd unit file for running the spritesheet generator as a service on
+# the Eleven Giants Vagrant dev box.
+
+[Unit]
+Description=Eleven Giants Spritesheet Generator
+Requires=rabbitmq-server.service
+After=rabbitmq-server.service
+
+[Service]
+User=vagrant
+Group=vagrant
+WorkingDirectory=/vagrant/eleven-spritesheet-generator
+ExecStart=/bin/bash -c 'source venv/bin/activate && python -m scripts/eleven_spritesheet_generator_worker --config=./config.py'
+
+[Install]
+WantedBy=multi-user.target

--- a/eleven/worker/tasks/__init__.py
+++ b/eleven/worker/tasks/__init__.py
@@ -59,6 +59,7 @@ class ElevenCelery(object):
                 (_, _, xvfb_threads) = multiproc.run_subproc(xvfb, '[xvfb]    ', wait=False)
                 # sleep for 1s to see if it's going to die
                 time.sleep(1)
+                xvfb.poll()
                 if xvfb.returncode is None:
                     # Xvfb is running
                     break


### PR DESCRIPTION
- add sample systemd unit files for running the spritesheet generator as a service
- more reliable subprocess exit code handling
